### PR TITLE
Fix monitor SG to support VPCs with multiple CIDR blocks

### DIFF
--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -43,7 +43,7 @@ resource "aws_security_group" "monitor_sg" {
     from_port   = 3100
     to_port     = 3100
     protocol    = "tcp"
-    cidr_blocks = [data.aws_vpc.default.cidr_block]
+    cidr_blocks = [for s in data.aws_vpc.default.cidr_block_associations : s.cidr_block]
   }
 
 


### PR DESCRIPTION
## Summary
- Fixes Loki ingress rule in the monitor security group to iterate over all VPC CIDR block associations instead of using the single primary CIDR block
- Prevents connectivity issues when the VPC has secondary CIDR ranges

## Test plan
- [ ] Verify `terraform plan` shows the expected SG rule change
- [ ] Apply and confirm Loki remains accessible from all VPC CIDR ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)